### PR TITLE
Improve the visibility of the format label in thumbnail view

### DIFF
--- a/windows-10/css/icons.css
+++ b/windows-10/css/icons.css
@@ -6,6 +6,15 @@
   /* */
 }
 
+.elfinder-cwd-icon:before {
+  color: white;
+  background: #70787d91;
+}
+
+.elfinder-cwd-icon:before {
+  background: #ffffffa6;
+}
+
 /* If you are using CSS sprites for your icons, set the background position
    in each of the below styles */
 /* Directory */


### PR DESCRIPTION
Hi, thanks for the nice work!

I would like to improve the appearance of the format label with this PR, in the latest version of elFinder, it look like this:
<img width="356" alt="Screenshot 2020-03-17 at 14 29 02" src="https://user-images.githubusercontent.com/478667/76860821-ed411700-685b-11ea-89b2-be0f24d118a9.png">

And I improved a bit to make it looks like the following:
<img width="352" alt="Screenshot 2020-03-17 at 14 28 20" src="https://user-images.githubusercontent.com/478667/76860826-f03c0780-685b-11ea-90c3-27f483c9a748.png">

Alternatively, I think we can also hide that label since windows 10 does have such a label.
